### PR TITLE
feat: Implement MoodActivity and Unsplash image display

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,4 +47,8 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+
+    implementation ("com.github.bumptech.glide:glide:4.16.0")
+    implementation("com.github.kittinunf.fuel:fuel-gson:2.3.1")
+    implementation("com.google.code.gson:gson:2.8.7")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,13 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
         </activity>
+
+        <activity
+            android:name=".MoodActivity"
+            android:exported="false" />
+
         <meta-data
             android:name="preloaded_fonts"
             android:resource="@array/preloaded_fonts" />

--- a/app/src/main/java/com/example/moodtunes/LastfmApiService.kt
+++ b/app/src/main/java/com/example/moodtunes/LastfmApiService.kt
@@ -34,4 +34,6 @@ class LastfmApiService(private val callback: LastfmLogic) {
             }
         })
     }
+
+
 }

--- a/app/src/main/java/com/example/moodtunes/MainActivity.kt
+++ b/app/src/main/java/com/example/moodtunes/MainActivity.kt
@@ -1,9 +1,11 @@
 package com.example.moodtunes
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.Log
+import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 
@@ -43,6 +45,17 @@ class MainActivity : AppCompatActivity(), WeatherLogic, GeolocationLogic, Lastfm
             )
         } else {
             geolocationApiService.fetchGeolocation()
+        }
+
+        findViewById<Button>(R.id.btnSongs).setOnClickListener {
+
+            // make methods to display songs and view here
+            Intent(this, MoodActivity::class.java).also { intent ->
+                intent.putExtra("MOOD_TAG", TAG.lowercase())
+                startActivity(intent)
+
+
+            }
         }
     }
 

--- a/app/src/main/java/com/example/moodtunes/MoodActivity.kt
+++ b/app/src/main/java/com/example/moodtunes/MoodActivity.kt
@@ -1,0 +1,111 @@
+package com.example.moodtunes
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.ImageView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.github.kittinunf.fuel.httpGet
+import com.github.kittinunf.result.Result
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import com.google.gson.annotations.SerializedName
+import java.util.concurrent.Executors
+
+
+class MoodActivity : AppCompatActivity() {
+
+    private lateinit var ivMoodImage: ImageView
+    private lateinit var rvTracks: RecyclerView
+    private lateinit var adapter: TrackAdapter
+    //private lateinit var outputTextView: TextView
+
+    private val executor = Executors.newSingleThreadExecutor()
+    private val handler = Handler(Looper.getMainLooper())
+
+    // api shiii
+    private  val UNSPLASH_BASE = "https://api.unsplash.com"
+    private  val UNSPLASH_ACCESS_KEY = "GSaXne8REsDlky9_XB2S8rB0MzxEdPGwUCJM2XrqFCk"
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.mood_activity)
+
+        ivMoodImage     = findViewById(R.id.ivMoodImage)
+        rvTracks        = findViewById(R.id.rvTracks)
+
+        adapter = TrackAdapter(emptyList())
+        rvTracks.layoutManager = LinearLayoutManager(this)
+        rvTracks.adapter       = adapter
+
+        val tag = intent.getStringExtra("MOOD_TAG") ?: "pop"
+        fetchUnsplashImage(tag)
+        //fetchTopTracks(tag)
+    }
+
+    private fun fetchUnsplashImage(query: String) {
+        val url = "https://api.unsplash.com/photos/random?query=$query"
+
+        executor.execute {
+            url
+                .httpGet()
+                .header("Authorization" to "Client-ID $UNSPLASH_ACCESS_KEY")
+                .responseString { _, response, result ->
+                    handler.post {
+                        when (result) {
+                            is Result.Success -> try {
+                                val data = result.get()
+                                val photo = Gson().fromJson(data, UnsplashResponse::class.java)
+                                Glide.with(this)
+                                    .load(photo.urls.regular)
+                                    .into(ivMoodImage)
+
+                            } catch (e: JsonSyntaxException) {
+                                Log.e("MoodActivity", "Unsplash JSON error", e)
+                            }
+
+                            is Result.Failure -> {
+                                Log.e(
+                                    "MoodActivity",
+                                    "Unsplash failed ${response.statusCode} ${response.responseMessage}",
+                                    result.getException()
+                                )
+                            }
+                        }
+                    }
+                }
+        }
+    }
+
+
+   /* private fun fetchTopTracks(tag: String) {
+        val lastfmService = LastfmApiService(this)
+        lastfmService.fetchTopTracks(tag)
+    }*/
+
+
+    // --- Data models ---
+
+    data class UnsplashResponse(val urls: Urls) {
+        data class Urls(val regular: String)
+    }
+
+    data class LastfmResponse(val tracks: TracksContainer) {
+        data class TracksContainer(
+            @SerializedName("track")
+            val trackList: List<LastfmTrack>
+        )
+    }
+
+    data class LastfmTrack(
+        val name: String,
+        val artist: Artist
+    )
+
+    data class Artist(val name: String)
+}

--- a/app/src/main/java/com/example/moodtunes/SimpleTrack.kt
+++ b/app/src/main/java/com/example/moodtunes/SimpleTrack.kt
@@ -1,0 +1,48 @@
+package com.example.moodtunes
+
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.moodtunes.MoodActivity.LastfmTrack
+
+data class SimpleTrack(val name: String, val artist: String)
+
+class TrackAdapter(
+    private var items: List<LastfmTrack>
+) : RecyclerView.Adapter<TrackAdapter.TrackVH>() {
+
+    inner class TrackVH(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val tvTitle  = itemView.findViewById<TextView>(R.id.tvTitle)
+        private val tvArtist = itemView.findViewById<TextView>(R.id.tvArtist)
+
+        fun bind(track: LastfmTrack) {
+            tvTitle.text  = track.name
+            tvArtist.text = track.artist.name
+        }
+    }
+
+
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrackVH {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.card_track, parent, false)
+        return TrackVH(view)
+    }
+
+    override fun onBindViewHolder(holder: TrackVH, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount() = items.size
+
+    fun updateTracks(newList: List<LastfmTrack>) {
+        items = newList
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/res/layout/card_track.xml
+++ b/app/src/main/res/layout/card_track.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="8dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/tvArtist"
+        android:textSize="14sp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+</LinearLayout>

--- a/app/src/main/res/layout/mood_activity.xml
+++ b/app/src/main/res/layout/mood_activity.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:background="@drawable/bg_gradient"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/ivMoodImage"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:scaleType="centerCrop"
+        android:contentDescription="Mood image"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvTracks"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="12dp"
+        android:layout_weight="1"/>
+
+</LinearLayout>


### PR DESCRIPTION
This commit introduces the `MoodActivity`, which fetches and displays a mood-based image from Unsplash. It also includes the basic setup for displaying a list of tracks, though the track fetching logic from Last.fm is currently commented out.

Key changes:
- **MainActivity:**
    - Added a "Give me Tunes!" button that navigates to `MoodActivity`, passing the determined mood tag.
- **MoodActivity:**
    - Created `MoodActivity.kt` to display mood-specific content.
    - Fetches and displays a random image from Unsplash based on the mood tag using the Glide library and Fuel for HTTP requests.
    - Sets up a `RecyclerView` with a `TrackAdapter` to display tracks (track data loading is not yet implemented in this activity).
    - Includes data models for Unsplash and Last.fm API responses.
- **TrackAdapter & SimpleTrack:**
    - Created `SimpleTrack.kt` containing the `SimpleTrack` data class and `TrackAdapter`.
    - `TrackAdapter` is responsible for binding track data (name and artist) to `RecyclerView` items.
- **Layouts:**
    - Added `mood_activity.xml` for the `MoodActivity` UI, including an `ImageView` for the mood image and a `RecyclerView` for tracks.
    - Added `card_track.xml` for the individual track item layout in the `RecyclerView`.
- **AndroidManifest.xml:**
    - Declared `MoodActivity`.
- **build.gradle.kts:**
    - Added dependencies for Glide, Fuel (for HTTP requests), and Gson.
- **LastfmApiService.kt:**
    - Minor code formatting (added newlines).